### PR TITLE
add some request info

### DIFF
--- a/datadog_builder/update.py
+++ b/datadog_builder/update.py
@@ -122,6 +122,7 @@ def _update_monitor(client, args, up_monitor, my_monitor):
                 client.update_monitor(up_monitor['id'], changes)
             except HTTPError:
                 LOG.exception("Monitor %(name)s failed to update", up_monitor)
+                LOG.info("Attempted request: ", changes)
 
     else:
         LOG.debug("No changes to monitor %(name)s id: %(id)s", up_monitor)


### PR DESCRIPTION
monitor creation and updating is currently failing on runs of datadog-builder.  this attempts to add some info to the logs to identify the issue.