### PR TITLE
Add roundtrip validation

### DIFF
--- a/datadog_builder/client.py
+++ b/datadog_builder/client.py
@@ -130,7 +130,13 @@ class DataDogClient(object):
         return self.request('DELETE', path, **kwargs)
 
     def create_monitor(self, monitor, **kwargs):
-        self.post('/monitor', json=monitor, **kwargs)
+        r = self.post('/monitor', json=monitor, **kwargs)
+        r.raise_for_status()
+        try:
+            res = r.json()
+        except ValueError:
+            return None
+        return res.get('id', None)
 
     def list_monitors(self, **kwargs):
         return self.get('/monitor', **kwargs).json()

--- a/datadog_builder/shell.py
+++ b/datadog_builder/shell.py
@@ -62,7 +62,7 @@ def main(argv=sys.argv[1:]):
         logging.config.dictConfig(logging_config)
 
     else:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.INFO)
 
     LOG.debug("Starting Up")
     args.func(args)


### PR DESCRIPTION
This adds a flag to the validate command (--round-trip), which does a create/delete of each monitor to verify that DataDog finds all monitors acceptable.

I initially thought this would be useful as a bonny check, but getting bonny the secrets sounds non-trivial, so I'm thinking it's better as a pre-commit hook that is run locally by whoever is creating monitors (@loafyloaf)

Fixes https://github.com/BonnyCI/projman/issues/223

